### PR TITLE
Document spec requirement for LF line endings

### DIFF
--- a/ncprop279.go
+++ b/ncprop279.go
@@ -242,6 +242,8 @@ func main() {
 	fmt.Println("INIT 1 0")
 
 	for {
+		// Prop279 Sec. 2.9.1 (2016 Oct 04) specifies LF as the line
+		// ending, even on OS's where CRLF is typical.
 		line, err := prop279Reader.ReadString('\n')
 
 		if err != nil {


### PR DESCRIPTION
This was not obvious to me from re-reading the code I wrote ages ago, so it's probably better to explicitly document this.