### PR TITLE
Warn on stderr if stream isolation ID is missing

### DIFF
--- a/ncprop279.go
+++ b/ncprop279.go
@@ -305,6 +305,9 @@ func main() {
 			if len(words) >= 4 {
 				streamID = words[3]
 			}
+			if streamID == "" {
+				fmt.Fprintf(os.Stderr, "WARNING: Missing stream isolation ID from Prop279 client; stream isolation won't work properly.  Maybe your Prop279 client is outdated?\n")
+			}
 
 			result := StatusNxDomain
 


### PR DESCRIPTION
A missing stream isolation ID is an indication that the Prop279 client is outdated, and it will break stream isolation, so we should warn about it rather than silently fall back to insecure behavior.