### PR TITLE
conf: example configuration file

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,22 @@
 
 You need [StemNS](https://github.com/namecoin/StemNS) or [TorNS](https://github.com/meejah/TorNS) in order to use `ncprop279`.  You also need a Nameecoin lookup client such as Namecoin Core, ConsensusJ-Namecoin, or Electrum-NMC.  Your StemNS/TorNS services configuration might look like this:
 
-~~~
+```
 _service_to_command = {
     "bit.onion": ['/path/to/ncprop279'],
     "bit": ['/path/to/ncprop279'],
 }
-~~~
+```
+
+ncprop279 can be configured by arguments on the command line (see `ncprop279 -help`)
+or by the same arguments listed in a configuration file. An example configuration
+file is provided in `ncprop279.conf` in this repository, uncomment and edit any
+desired lines. Note that the `[ncprop279]` section header is required. This configuration
+file will not be used automatically. To specify command line arguments directly
+or give a path to the configuration file, append to the list in the map
+mentioned above:
+
+    "bit.onion": ['/path/to/ncprop279', '-conf=/path/to/ncprop279.conf']
 
 ## Security Notes
 

--- a/ncprop279.conf
+++ b/ncprop279.conf
@@ -1,0 +1,22 @@
+[ncprop279]
+
+# Maximum name cache entries
+# cachemaxentries=100
+
+# Namecoin RPC server address
+# namecoinrpcaddress="127.0.0.1:8336"
+
+# Namecoin RPC cookie path (used if password is unspecified)
+# namecoinrpccookiepath=""
+
+# Namecoin RPC password
+# namecoinrpcpassword=""
+
+# Timeout (in milliseconds) for Namecoin RPC requests
+# namecoinrpctimeout=1500
+
+# Namecoin RPC username
+# namecoinrpcusername=""
+
+# Only return onion services? (default false)
+# onlyonion=false


### PR DESCRIPTION
Useful to clarify the format of the config file, which is not
easy to guess.