### PR TITLE
Cirrus: Initialize Go modules for certinject

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -31,11 +31,11 @@ task:
         - cd ../
         - git clone https://github.com/namecoin/certinject.git
         - cd certinject
-        #- go mod init github.com/namecoin/certinject
-        #- go mod tidy
+        - go mod init github.com/namecoin/certinject
+        - go mod tidy
         - go generate ./...
-        #- go mod tidy
-        #- go install -v ./...
+        - go mod tidy
+        - go install -v ./...
       x509_script:
         - cd $(go env GOPATH)/src/github.com/"$CIRRUS_REPO_FULL_NAME"
         - cd ../
@@ -125,11 +125,11 @@ task:
         - cd ../
         - git clone https://github.com/namecoin/certinject.git
         - cd certinject
-        #- go mod init github.com/namecoin/certinject
-        #- go mod tidy
+        - go mod init github.com/namecoin/certinject
+        - go mod tidy
         - go generate ./...
-        #- go mod tidy
-        #- go install -v ./...
+        - go mod tidy
+        - go install -v ./...
       x509_script:
         - cd $(go env GOPATH)/src/github.com/"$CIRRUS_REPO_FULL_NAME"
         - cd ../
@@ -195,11 +195,11 @@ task:
         - cd ../
         - git clone https://github.com/namecoin/certinject.git
         - cd certinject
-        #- go mod init github.com/namecoin/certinject
-        #- go mod tidy
+        - go mod init github.com/namecoin/certinject
+        - go mod tidy
         - go generate ./...
-        #- go mod tidy
-        #- go install -v ./...
+        - go mod tidy
+        - go install -v ./...
       x509_script:
         - cd $(go env GOPATH)/src/github.com/"$CIRRUS_REPO_FULL_NAME"
         - cd ../


### PR DESCRIPTION
Fixes build error during `fetch` instruction.