### PR TITLE
Cirrus: Make "Modules Off" tasks mandatory again

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -16,7 +16,6 @@ task:
         GO111MODULE: "off"
         GOLANGCI_MODULES_ARGS: "--disable=gomoddirectives,gomodguard"
         MODULES_NAME: " Modules Off"
-      allow_failures: true # TODO: Re-enable this after btcd v0.22.1 is tagged.
       fetch_script:
         - go get -tags "$GOX_TAGS" -d -v -t github.com/$CIRRUS_REPO_FULL_NAME/...
         - GOOS=windows go get -tags "$GOX_TAGS" -d -v -t github.com/$CIRRUS_REPO_FULL_NAME/...
@@ -113,7 +112,6 @@ task:
     - env:
         GO111MODULE: "off"
         MODULES_NAME: " Modules Off"
-      allow_failures: true # TODO: Re-enable this after btcd v0.22.1 is tagged.
       fetch_script:
         - go get -tags "$GOX_TAGS" -d -v -t github.com/$CIRRUS_REPO_FULL_NAME/...
         - GOOS=windows go get -tags "$GOX_TAGS" -d -v -t github.com/$CIRRUS_REPO_FULL_NAME/...
@@ -182,7 +180,6 @@ task:
     - env:
         GO111MODULE: "off"
         MODULES_NAME: " Modules Off"
-      allow_failures: true # TODO: Re-enable this after btcd v0.22.1 is tagged.
       gox_script:
         - go get github.com/mitchellh/gox
       fetch_script:


### PR DESCRIPTION
The btcd issue that made them non-mandatory is resolved.