### PR TITLE
Cirrus: Use local clone of go-systemd

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -25,13 +25,17 @@ task:
     - env:
         GOLANGCI_MODULES_ARGS: ""
         MODULES_NAME: ""
+      systemd_script:
+        - mkdir -p $(go env GOPATH)/src/github.com/coreos
+        - cd $(go env GOPATH)/src/github.com/coreos
+        - git clone https://github.com/coreos/go-systemd.git
       certinject_script:
         - cd $(go env GOPATH)/src/github.com/"$CIRRUS_REPO_FULL_NAME"
         - cd ../
         - git clone https://github.com/namecoin/certinject.git
         - cd certinject
         - go mod init github.com/namecoin/certinject
-        - go mod edit -replace github.com/coreos/go-systemd=github.com/coreos/go-systemd/v22@latest
+        - go mod edit -replace github.com/coreos/go-systemd=$(go env GOPATH)/src/github.com/coreos/go-systemd
         - go mod tidy
         - go generate ./...
         - go mod tidy
@@ -50,7 +54,7 @@ task:
         - cd $(go env GOPATH)/src/github.com/"$CIRRUS_REPO_FULL_NAME"
         - go mod init github.com/"$CIRRUS_REPO_FULL_NAME"
         # TODO: Remove btcd from this line after v0.22.1 is tagged
-        - go mod edit -replace github.com/coreos/go-systemd=github.com/coreos/go-systemd/v22@latest -replace github.com/namecoin/certinject=../certinject -replace github.com/namecoin/x509-compressed=../x509-compressed -replace github.com/btcsuite/btcd=github.com/btcsuite/btcd@latest
+        - go mod edit -replace github.com/coreos/go-systemd=$(go env GOPATH)/src/github.com/coreos/go-systemd -replace github.com/namecoin/certinject=../certinject -replace github.com/namecoin/x509-compressed=../x509-compressed -replace github.com/btcsuite/btcd=github.com/btcsuite/btcd@latest
         - go mod tidy
   lint_script:
     - cd $(go env GOPATH)/src/github.com/$CIRRUS_REPO_FULL_NAME/
@@ -120,13 +124,17 @@ task:
         - go get -tags "$GOX_TAGS" -d -v -t github.com/$CIRRUS_REPO_FULL_NAME/...
     - env:
         MODULES_NAME: ""
+      systemd_script:
+        - mkdir -p $(go env GOPATH)/src/github.com/coreos
+        - cd $(go env GOPATH)/src/github.com/coreos
+        - git clone https://github.com/coreos/go-systemd.git
       certinject_script:
         - cd $(go env GOPATH)/src/github.com/"$CIRRUS_REPO_FULL_NAME"
         - cd ../
         - git clone https://github.com/namecoin/certinject.git
         - cd certinject
         - go mod init github.com/namecoin/certinject
-        - go mod edit -replace github.com/coreos/go-systemd=github.com/coreos/go-systemd/v22@latest
+        - go mod edit -replace github.com/coreos/go-systemd=$(go env GOPATH)/src/github.com/coreos/go-systemd
         - go mod tidy
         - go generate ./...
         - go mod tidy
@@ -145,7 +153,7 @@ task:
         - cd $(go env GOPATH)/src/github.com/"$CIRRUS_REPO_FULL_NAME"
         - go mod init github.com/"$CIRRUS_REPO_FULL_NAME"
         # TODO: Remove btcd from this line after v0.22.1 is tagged
-        - go mod edit -replace github.com/coreos/go-systemd=github.com/coreos/go-systemd/v22@latest -replace github.com/namecoin/certinject=../certinject -replace github.com/namecoin/x509-compressed=../x509-compressed -replace github.com/btcsuite/btcd=github.com/btcsuite/btcd@latest
+        - go mod edit -replace github.com/coreos/go-systemd=$(go env GOPATH)/src/github.com/coreos/go-systemd -replace github.com/namecoin/certinject=../certinject -replace github.com/namecoin/x509-compressed=../x509-compressed -replace github.com/btcsuite/btcd=github.com/btcsuite/btcd@latest
         - go mod tidy
         # Get the test suite
         - mkdir -p $(go env GOPATH)/src/github.com/hlandau
@@ -190,13 +198,17 @@ task:
         - go get -tags "$GOX_TAGS" -d -v -t github.com/$CIRRUS_REPO_FULL_NAME/...
     - env:
         MODULES_NAME: ""
+      systemd_script:
+        - mkdir -p $(go env GOPATH)/src/github.com/coreos
+        - cd $(go env GOPATH)/src/github.com/coreos
+        - git clone https://github.com/coreos/go-systemd.git
       certinject_script:
         - cd $(go env GOPATH)/src/github.com/"$CIRRUS_REPO_FULL_NAME"
         - cd ../
         - git clone https://github.com/namecoin/certinject.git
         - cd certinject
         - go mod init github.com/namecoin/certinject
-        - go mod edit -replace github.com/coreos/go-systemd=github.com/coreos/go-systemd/v22@latest
+        - go mod edit -replace github.com/coreos/go-systemd=$(go env GOPATH)/src/github.com/coreos/go-systemd
         - go mod tidy
         - go generate ./...
         - go mod tidy
@@ -217,7 +229,7 @@ task:
         - cd $(go env GOPATH)/src/github.com/"$CIRRUS_REPO_FULL_NAME"
         - go mod init github.com/"$CIRRUS_REPO_FULL_NAME"
         # TODO: Remove btcd from this line after v0.22.1 is tagged
-        - go mod edit -replace github.com/coreos/go-systemd=github.com/coreos/go-systemd/v22@latest -replace github.com/namecoin/certinject=../certinject -replace github.com/namecoin/x509-compressed=../x509-compressed -replace github.com/btcsuite/btcd=github.com/btcsuite/btcd@latest
+        - go mod edit -replace github.com/coreos/go-systemd=$(go env GOPATH)/src/github.com/coreos/go-systemd -replace github.com/namecoin/certinject=../certinject -replace github.com/namecoin/x509-compressed=../x509-compressed -replace github.com/btcsuite/btcd=github.com/btcsuite/btcd@latest
         - go mod tidy
   build_script:
     - rm -rf idist


### PR DESCRIPTION
Works around Go modules fail.

See https://github.com/hlandau/dexlogconfig/issues/7