### PR TITLE
redame: add  build instructions, and add commands godebug stub

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,61 @@
 
 `ncprop279` acts as a bridge between Tor Prop279 clients and Namecoin; it can be used for Namecoin naming in Tor.  Unlike `dns-prop279`, it does not use the DNS wire protocol.  This reduces attack surface and binary size, but prevents delegation from Namecoin to DNS via NS/DS records.
 
+## Building
+
+### Prerequisites:
+
+Ensure you have the Go tools installed.
+
+### Option A: Using Go get commands without Go modules
+
+Should work on any platform with Bash; only Go 1.15-1.16.x; will not work on Go 1.17+:
+
+1. Ensure you have the `GOPATH` environment variable set. (For those not
+   familar with Go, setting it to the path to an empty directory will suffice.
+   The directory will be filled with build files.)
+
+2. To disable Go modules:
+
+      export GO111MODULE=off
+
+3. To retrieve the source code automatically:
+
+      go get -d -t -u github.com/namecoin/ncprop279/...
+
+4. To perform a necessary build step that parses ReactOS property list and applies compressed public key patch:
+
+      go generate github.com/namecoin/certinject/...
+      go generate github.com/namecoin/x509-compressed/...
+
+6. To build the ncprop279 binary at `$GOPATH/bin/ncprop279`.
+
+      go get -t -u github.com/namecoin/ncprop279/...
+
+### Option B: Using Go mod commands with Go modules
+
+Should work on any platform with Bash; Go 1.15+:
+
+1. Clone [certinject](https://github.com/namecoin/certinject), [x509-compressed](https://github.com/namecoin/x509-compressed), and ncdns to sibling directories.
+
+2. Install `certinject` according to its instructions.
+
+3. Install `x509-compressed` according to its "with Go modules" instructions.
+
+4. Setup Go modules in the ncprop279 directory:
+ 
+       go mod init github.com/namecoin/ncdns
+       go mod edit -replace github.com/coreos/go-systemd=github.com/coreos/go-systemd/v22@latest -replace github.com/namecoin/certinject=../certinject -replace github.com/namecoin/x509-compressed=../x509-compressed
+       go mod tidy
+
+5. Compile the ncprop279 binary in the ncprop279 directory:
+
+       go build ./..
+
+6. Optionally, install into `$GOPATH` at `$GOPATH/bin/ncprop279`:
+
+       go install ./...
+
 ## Usage
 
 You need [StemNS](https://github.com/namecoin/StemNS) or [TorNS](https://github.com/meejah/TorNS) in order to use `ncprop279`.  You also need a Namecoin lookup client such as Namecoin Core, ConsensusJ-Namecoin, or Electrum-NMC.  Your StemNS/TorNS services configuration might look like this:

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Should work on any platform with Bash; Go 1.15+:
 4. Setup Go modules in the ncprop279 directory:
  
        go mod init github.com/namecoin/ncdns
-       go mod edit -replace github.com/coreos/go-systemd=github.com/coreos/go-systemd/v22@latest -replace github.com/namecoin/certinject=../certinject -replace github.com/namecoin/x509-compressed=../x509-compressed
+       go mod edit -replace github.com/coreos/go-systemd=github.com/coreos/go-systemd/v22@latest -replace github.com/namecoin/certinject=../certinject -replace github.com/namecoin/x509-compressed=../x509-compressed -replace github.com/namecoin/x509-compressed/godebug=../x509-compressed/godebug
        go mod tidy
 
 5. Compile the ncprop279 binary in the ncprop279 directory:


### PR DESCRIPTION
See [PR#4](https://github.com/namecoin/x509-compressed/pull/4) in x509-compressed that introduced the godebug stub as a way to transparently handle code that references the non-importable internal/godebug package.